### PR TITLE
Fixing bugs, support for C++ projects, GLCD_PrintDouble modified

### DIFF
--- a/Files/SSD1306.c
+++ b/Files/SSD1306.c
@@ -371,7 +371,8 @@ void GLCD_DrawBitmap(const uint8_t *Bitmap, uint8_t Width, const uint8_t Height,
 	}
 
 	//#6 - Update last line, if needed
-	if (lines > 1)
+	//If (LINE_STARTING != LINE_ENDING)
+	if (__GLCD_getLine(y2) != __GLCD_getLine((y2 + __GLCD.Font.Height - 1)) && y < __GLCD_Screen_Height)
 	{
 		//Go to the start of the line
 		GLCD_GotoXY(x, y);

--- a/Files/SSD1306.c
+++ b/Files/SSD1306.c
@@ -7,7 +7,7 @@ GLCD_t __GLCD;
 
 #define __I2C_SLA_W(Address)		(Address<<1)
 #define __I2C_SLA_R(Address)		((Address<<1) | (1<<0))
-#define __GLCD_getLine(Y)			(Y / __GLCD_Screen_Height)
+#define __GLCD_getLine(Y)			(Y / __GLCD_Screen_Line_Height)
 #define __GLCD_Min(X, Y)			((X < Y) ? X : Y)
 #define __GLCD_AbsDiff(X, Y)		((X > Y) ? (X - Y) : (Y - X))
 #define __GLCD_Swap(X, Y)			do { typeof(X) t = X; X = Y; Y = t; } while (0)
@@ -185,7 +185,7 @@ void GLCD_GotoX(const uint8_t X)
 
 void GLCD_GotoY(const uint8_t Y)
 {
-	if (__GLCD.Y < __GLCD_Screen_Height)
+	if (Y < __GLCD_Screen_Height)
 		__GLCD.Y = Y;
 }
 
@@ -998,7 +998,7 @@ void GLCD_PrintChar(char Character)
 
 	//#7 - Update last line, if needed
 	//If (LINE_STARTING != LINE_ENDING)
-	if (__GLCD_getLine(y2) != __GLCD_getLine(y2 + __GLCD.Font.Height))
+	if (__GLCD_getLine(y2) != __GLCD_getLine((y2 + __GLCD.Font.Height - 1)) && y < __GLCD_Screen_Height)
 	{
 		//Go to the start of the line
 		GLCD_GotoXY(x, y);
@@ -1080,7 +1080,7 @@ void GLCD_PrintInteger(const int32_t Value)
 	}
 }
 
-void GLCD_PrintDouble(double Value, const uint32_t Tens)
+void GLCD_PrintDouble(double Value, const uint8_t Precision)
 {
 	if (Value == 0)
 	{
@@ -1105,7 +1105,7 @@ void GLCD_PrintDouble(double Value, const uint32_t Tens)
 		GLCD_PrintChar('.');
 		
 		//Print decimal part
-		GLCD_PrintInteger((Value - (uint32_t)(Value)) * Tens);
+		GLCD_PrintInteger((Value - (uint32_t)(Value)) * pow(10, Precision));
 	}
 }
 
@@ -1227,7 +1227,7 @@ static void Int2bcd(int32_t Value, char BCD[])
 		Value = -Value;
 	}
 	
-	while (Value > 1000000000)
+	while (Value >= 1000000000)
 	{
 		Value -= 1000000000;
 		BCD[1]++;

--- a/Files/SSD1306.c
+++ b/Files/SSD1306.c
@@ -372,7 +372,7 @@ void GLCD_DrawBitmap(const uint8_t *Bitmap, uint8_t Width, const uint8_t Height,
 
 	//#6 - Update last line, if needed
 	//If (LINE_STARTING != LINE_ENDING)
-	if (__GLCD_getLine(y2) != __GLCD_getLine((y2 + __GLCD.Font.Height - 1)) && y < __GLCD_Screen_Height)
+	if (__GLCD_getLine(y2) != __GLCD_getLine((y2 + Height - 1)) && y < __GLCD_Screen_Height)
 	{
 		//Go to the start of the line
 		GLCD_GotoXY(x, y);

--- a/Files/SSD1306.h
+++ b/Files/SSD1306.h
@@ -24,6 +24,11 @@
 #include "TWI.h"
 //--------------------------//
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 //----- Auxiliary data ---------------------------//
 #define __GLCD_I2C_Address							0x3C	//0x3C or 0x3D
 
@@ -203,6 +208,11 @@ void GLCD_PrintChar(char Character);
 void GLCD_PrintString(const char *Text);
 void GLCD_PrintString_P(const char *Text);
 void GLCD_PrintInteger(const int32_t Value);
-void GLCD_PrintDouble(double Value, const uint32_t Tens);
+void GLCD_PrintDouble(double Value, const uint8_t Precision);
 //-----------------------------------------------------------------------------//
+	
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
I have fixed some bugs and modified GLCD_PrintDouble function. Support for C++ project was made using extern "C" written directly into SSD1306.h file.
(You can take a look at my library based on yours to support devices with USI interface and small RAM: https://github.com/Tekl7/AVR-SSD1306-Library)